### PR TITLE
Fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "test": "tests"
   },
   "dependencies": {
-    "codemirror": "^5.9.0"
+    "memory-helper": "^1.1.1"
   },
   "devDependencies": {
+    "codemirror": "^5.9.0",
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.2.0",
     "benchmark": "^2.1.0",


### PR DESCRIPTION
`memory-helper` is not included in the dependencies, so if you install `genish.js` from npm, it doesn't work. Also `codemirror` dependency should be in development. This PR fixes both.
